### PR TITLE
Added new exporter for creating pattern partials lookup JS module

### DIFF
--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -17,6 +17,7 @@ use \PatternLab\Config;
 use \PatternLab\Data;
 use \PatternLab\Dispatcher;
 use \PatternLab\Parsers\Documentation;
+use \PatternLab\PatternData\Exporters\LookupPartialsExporter;
 use \PatternLab\PatternData\Exporters\NavItemsExporter;
 use \PatternLab\PatternData\Exporters\PatternPartialsExporter;
 use \PatternLab\PatternData\Exporters\PatternPathDestsExporter;
@@ -197,6 +198,12 @@ class Builder {
 		
 		// write out the data
 		file_put_contents($dataDir."/patternlab-data.js",$output);
+
+		// Load and write out the items for the partials lookup
+		$lpExporter = new LookupPartialsExporter();
+		$lookup = $lpExporter->run();
+		$lookupData = "module.exports = { lookup: " . json_encode($lookup) . "};";
+		file_put_contents($dataDir."/patternLabPartials.js",$lookupData);
 		
 		// note the end of the operation
 		$dispatcherInstance->dispatch("builder.generateIndexEnd");

--- a/src/PatternLab/PatternData/Exporters/LookupPartialsExporter.php
+++ b/src/PatternLab/PatternData/Exporters/LookupPartialsExporter.php
@@ -1,0 +1,36 @@
+<?php
+
+/*!
+ * Pattern Data Nav Items Exporter Class
+ *
+ * Copyright (c) 2015 Ian Devlin
+ * Licensed under the MIT license
+ *
+ * Generates a lookup array of partials to src paths for Pattern Lab
+ *
+ */
+
+namespace PatternLab\PatternData\Exporters;
+
+use \PatternLab\PatternData;
+
+class LookupPartialsExporter extends \PatternLab\PatternData\Exporter {
+    public function __construct($options = array()) {
+
+        parent::__construct($options);
+
+    }
+
+    public function run() {
+        $lookupPartials = array();
+
+        $store = PatternData::get();
+        foreach ($store as $patternStoreKey => $patternStoreData) {
+            if ($patternStoreData["category"] == "pattern") {
+                $lookupPartials[$patternStoreData["partial"]] = $patternStoreData["pathName"];
+            }
+        }
+
+        return $lookupPartials;
+    }
+}


### PR DESCRIPTION
Added new exporter and implementation that create a simple JS module (patternLabPartials.js) that allows a lookup of a Pattern Lab's pattern src path using its pattern name.
